### PR TITLE
#67: Add second footer widget section

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -41,6 +41,9 @@ SMNTCS Retro bundles the following third-party resources:
 
 == Changelog ==
 
+=== 1.4 (2020.03.20) ===
+* [Add second footer widget section](https://github.com/nielslange/smntcs-retro/issues/67)
+
 === 1.3 (2020.03.15) ===
 * [Add 404 page](https://github.com/nielslange/smntcs-retro/issues/63)
 * [Add menu level limitation to README.txt](https://github.com/nielslange/smntcs-retro/issues/57)

--- a/footer.php
+++ b/footer.php
@@ -39,7 +39,17 @@
 
 			<div id="footer-widget-wrapper">
 
-				<?php dynamic_sidebar( 'footer-sidebar' ); ?>
+				<div id="footer-widget-wrapper-left">
+
+					<?php dynamic_sidebar( 'footer-sidebar-left' ); ?>
+
+				</div><!-- #footer-widget-wrapper-left -->
+
+				<div id="footer-widget-wrapper-left">
+
+					<?php dynamic_sidebar( 'footer-sidebar-right' ); ?>
+					
+				</div><!-- #footer-widget-wrapper-left -->
 
 			</div><!-- #footer-widget-wrapper -->
 

--- a/footer.php
+++ b/footer.php
@@ -48,7 +48,7 @@
 				<div id="footer-widget-wrapper-left">
 
 					<?php dynamic_sidebar( 'footer-sidebar-right' ); ?>
-					
+
 				</div><!-- #footer-widget-wrapper-left -->
 
 			</div><!-- #footer-widget-wrapper -->

--- a/functions.php
+++ b/functions.php
@@ -144,9 +144,21 @@ function smntcs_retro_sidebars() {
 
 	register_sidebar(
 		array(
-			'id'            => 'footer-sidebar',
-			'name'          => __( 'Footer Sidebar', 'smntcs-retro' ),
-			'description'   => __( 'Add widgets to the footer sidebar.', 'smntcs-retro' ),
+			'id'            => 'footer-sidebar-left',
+			'name'          => __( 'Footer Sidebar Left', 'smntcs-retro' ),
+			'description'   => __( 'Add widgets to the footer sidebar left.', 'smntcs-retro' ),
+			'before_widget' => '<div id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</div>',
+			'before_title'  => '<h3 class="widget-title">',
+			'after_title'   => '</h3>',
+		)
+	);
+
+	register_sidebar(
+		array(
+			'id'            => 'footer-sidebar-right',
+			'name'          => __( 'Footer Sidebar Right', 'smntcs-retro' ),
+			'description'   => __( 'Add widgets to the footer sidebar right.', 'smntcs-retro' ),
 			'before_widget' => '<div id="%1$s" class="widget %2$s">',
 			'after_widget'  => '</div>',
 			'before_title'  => '<h3 class="widget-title">',

--- a/style.css
+++ b/style.css
@@ -383,6 +383,19 @@ article p:first-of-type {
 	margin-bottom: 1em;
 }
 
+@media screen and (min-width: 580px) {
+
+	#footer-widget-wrapper {
+		display: flex;
+	}
+
+	#footer-widget-wrapper-left,
+	#footer-widget-wrapper-right {
+		padding-right: 2em;
+	}
+}
+
 #footer-credits-wrapper {
 	margin-bottom: 1em;
 }
+


### PR DESCRIPTION
Fixes #67 

<table>
<tr>
<td>Before:
<br><br>

![#67-before](https://user-images.githubusercontent.com/3323310/77162530-bd557600-6ade-11ea-9e03-b2ffda05e119.png)
</td>
<td>After:
<br><br>

![#67-after](https://user-images.githubusercontent.com/3323310/77162580-e0802580-6ade-11ea-8f6e-6adf196607ac.png)
</td>
</tr>
</table>