### PR TITLE
#77: Fix image with when using classic editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ SMNTCS Retro bundles the following third-party resources:
 
 ## Changelog
 
+### 1.7 (2020.04.08)
+* [Fix image with when using classic editor](https://github.com/nielslange/smntcs-retro/issues/77)
+
 ### 1.6 (2020.03.29)
 * [Add theme option to centre site](https://github.com/nielslange/smntcs-retro/issues/74)
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Contributors: nielslange
 Requires at least: 4.7
 Tested up to: WordPress 5.4
 Requires PHP: 5.6
-Stable tag: 1.6.1
+Stable tag: 1.7
 License: GPLv3 or later  
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html  
 
@@ -40,6 +40,9 @@ SMNTCS Retro bundles the following third-party resources:
 * URL: https://github.com/source-foundry/Hack/  
 
 == Changelog ==
+
+=== 1.7 (2020.04.08) === 
+* [Fix image with when using classic editor](https://github.com/nielslange/smntcs-retro/issues/77)
 
 === 1.6 (2020.03.29) ===
 * [Add theme option to centre site](https://github.com/nielslange/smntcs-retro/issues/74)

--- a/functions.php
+++ b/functions.php
@@ -211,9 +211,9 @@ function smntcs_retro_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'smntcs_retro_centre_site',
 		array(
-			'default' 					=> false,
+			'default'           => false,
 			'sanitize_callback' => 'sanitize_checkbox',
-			'type'    					=> 'theme_mod',
+			'type'              => 'theme_mod',
 		)
 	);
 

--- a/rtl.css
+++ b/rtl.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/nielslange/retro/
 Author: Niels Lange
 Author URI: https://nielslange.de/
 Description: SMNTCS Retro is a minimalistic theme for the average nerd.
-Version: 1.6.1
+Version: 1.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: smntcs-retro
@@ -312,6 +312,10 @@ article p:first-of-type {
 /* Articles ************************************/
 #site-content-posts article {
 	margin: 2em 0 4em;
+}
+
+#site-content-posts article img {
+	max-width: 100%;
 }
 
 /* Search form *********************************/

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/nielslange/retro/
 Author: Niels Lange
 Author URI: https://nielslange.de/
 Description: SMNTCS Retro is a minimalistic theme for the average nerd.
-Version: 1.6.1
+Version: 1.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: smntcs-retro
@@ -312,6 +312,10 @@ article p:first-of-type {
 /* Articles ************************************/
 #site-content-posts article {
 	margin: 2em 0 4em;
+}
+
+#site-content-posts article img {
+	max-width: 100%;
 }
 
 /* Search form *********************************/


### PR DESCRIPTION
Fixes #77 

<table>
<tr>
<td>Before:
<br><br>

![#77-before](https://user-images.githubusercontent.com/3323310/78779432-25ed8f80-79c7-11ea-8269-df1450d32687.png)
</td>
<td>After:
<br><br>

![#77-after](https://user-images.githubusercontent.com/3323310/78779427-2423cc00-79c7-11ea-9ef7-f12023fe1f49.png)
</td>
</tr>
</table>